### PR TITLE
Enable automatic Futbin URL lookup when managing players

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ python google_sheets_connector_v2.py YOUR_SPREADSHEET_ID
 # Manage players locally
 python manage_players.py
 
+# Quickly add a player by name (URL auto-detected)
+python manage_players.py add "Kylian Mbappé"
+
 # Run crawler with JSON config
 python crawler_with_config.py
 ```


### PR DESCRIPTION
## Summary
- add a Futbin search integration to the player manager so names can automatically resolve to market URLs
- extend the CLI with an explicit search command, interactive result selection, and documentation on the new workflow

## Testing
- python -m compileall manage_players.py

------
https://chatgpt.com/codex/tasks/task_e_68de034a27308326a5cbedf97a5945a7