### PR TITLE
Add bulk Futbin player import to manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,16 @@ python manage_players.py
 # Quickly add a player by name (URL auto-detected)
 python manage_players.py add "Kylian Mbappé"
 
+# Import batches of players directly from Futbin listings (page range optional)
+python manage_players.py import_all 1 10 500
+
 # Run crawler with JSON config
 python crawler_with_config.py
 ```
+
+The optional arguments represent `START_PAGE`, `END_PAGE` and `MAX` players to import, so the
+example above will crawl Futbin pages 1 through 10 and stop after registering 500 new players. If
+you omit the last parameters the importer continues until Futbin stops returning results.
 
 
 ## 🔗 Google Sheets Integration Details


### PR DESCRIPTION
## Summary
- add a Futbin listing crawler to the player manager so full catalogues can be imported automatically
- expose the bulk importer through the CLI/interactive workflow with progress feedback
- document the new `import_all` command and its optional arguments in the README

## Testing
- python -m compileall manage_players.py

------
https://chatgpt.com/codex/tasks/task_e_68de050c6284832698c10dcb69005947