### PR TITLE
Add continuous monitoring mode with buy recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ The optional arguments represent `START_PAGE`, `END_PAGE` and `MAX` players to i
 example above will crawl Futbin pages 1 through 10 and stop after registering 500 new players. If
 you omit the last parameters the importer continues until Futbin stops returning results.
 
+#### Continuous Monitoring Mode
+
+Add the following keys to the `settings` block in `player_links.json` to keep the crawler running
+indefinitely and highlight buying opportunities as prices move:
+
+```json
+  "settings": {
+    ...,
+    "continuous_monitoring": true,
+    "monitoring_interval_seconds": 300,
+    "price_drop_threshold": 0.10,
+    "target_profit_margin": 0.08
+  }
+```
+
+- `continuous_monitoring` – enables the always-on loop.
+- `monitoring_interval_seconds` – wait time between full scans (minimum 10 seconds).
+- `price_drop_threshold` – minimum relative drop versus the previous cycle to trigger a signal (e.g. `0.10` = 10%).
+- `target_profit_margin` – desired margin between the cheapest listing and the reference price (Average BIN or EA Avg) to flag a card as a buy.
+
+Run `python crawler_with_config.py` and the script will keep cycling until you press **Ctrl+C**.
+A snapshot of the latest prices and a summary report are stored when you exit.
+
 
 ## 🔗 Google Sheets Integration Details
 


### PR DESCRIPTION
## Summary
- add a continuous monitoring loop that reuses the crawler to watch price changes and flag buy opportunities based on configurable thresholds
- allow saving and reporting of the latest monitoring snapshot and reuse the price formatter for quieter runs
- document the new JSON settings required to enable the continuous monitoring workflow

## Testing
- python -m compileall crawler_with_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e00d7a27a08326a0c68d5e39329028